### PR TITLE
BinaryTree in DynamicMesh_Class

### DIFF
--- a/src/modules/DynamicMesh/src/DynamicMesh_Class.F90
+++ b/src/modules/DynamicMesh/src/DynamicMesh_Class.F90
@@ -23,6 +23,7 @@ USE GlobalData, ONLY: DFP, I4B, LGT
 USE ExceptionHandler_Class, ONLY: e
 USE HDF5File_Class, ONLY: HDF5File_
 USE ElemData_Class
+USE ElemDataBinaryTree_Class
 USE ElemDataList_Class
 USE NodeData_Class
 USE NodeDataList_Class
@@ -35,7 +36,7 @@ PRIVATE
 PUBLIC :: DynamicMesh_
 PUBLIC :: DynamicMeshPointer_
 
-CHARACTER(*), PARAMETER :: modName = "Mesh_Class"
+CHARACTER(*), PARAMETER :: modName = "DynamicMesh_Class"
 
 !----------------------------------------------------------------------------
 !                                                                     Mesh_
@@ -49,11 +50,13 @@ CHARACTER(*), PARAMETER :: modName = "Mesh_Class"
 
 TYPE, EXTENDS(AbstractMesh_) :: DynamicMesh_
   TYPE(ElemDataList_) :: elementDataList
-  !! element data
-  TYPE(NodeDataBinaryTree_) :: nodeDataBinaryTree
-  !! node data
+  !! ElemData list
+  TYPE(ElemDataBinaryTree_) :: elementDataBinaryTree
+  !! ElemData binary tree
   TYPE(NodeDataList_) :: nodeDataList
   !! NodeData list
+  TYPE(NodeDataBinaryTree_) :: nodeDataBinaryTree
+  !! NodeData binary tree
 
 CONTAINS
   PRIVATE
@@ -70,15 +73,18 @@ CONTAINS
     !! Read mesh from hdf5 file
   PROCEDURE, PUBLIC, PASS(obj) :: Display => obj_Display
     !! Display the content
-  PROCEDURE, PUBLIC, PASS(obj) :: DisplayNodeData => obj_DisplayNodeData
+  PROCEDURE, PUBLIC, PASS(obj) :: DisplayNodeData =>  &
+    & obj_DisplayNodeData
     !! Display node data
-  PROCEDURE, PUBLIC, PASS(obj) :: DisplayElementData => obj_DisplayElementData
+  PROCEDURE, PUBLIC, PASS(obj) :: DisplayElementData =>  &
+    & obj_DisplayElementData
     !! Display element data
 
   ! SET:
   ! @NodeDataMethods
   PROCEDURE, PUBLIC, PASS(obj) :: InitiateNodeToElements => &
     & obj_InitiateNodeToElements
+
   !! Initiate node to node data
   ! PROCEDURE, PUBLIC, PASS(obj) :: InitiateNodeToNodes => &
   !   & obj_InitiateNodetoNodes

--- a/src/submodules/DynamicMesh/src/DynamicMesh_Class@ConstructorMethods.F90
+++ b/src/submodules/DynamicMesh/src/DynamicMesh_Class@ConstructorMethods.F90
@@ -34,8 +34,14 @@ END PROCEDURE obj_Final
 MODULE PROCEDURE obj_Deallocate
 CALL AbstractMeshDeallocate(obj)
 CALL obj%elementDataList%DEALLOCATE()
+CALL obj%elementDataBinaryTree%DEALLOCATE()
+
 CALL obj%nodeDataList%DEALLOCATE()
 CALL obj%nodeDataBinaryTree%DEALLOCATE()
 END PROCEDURE obj_Deallocate
+
+!----------------------------------------------------------------------------
+!
+!----------------------------------------------------------------------------
 
 END SUBMODULE ConstructorMethods

--- a/src/submodules/DynamicMesh/src/DynamicMesh_Class@IOMethods.F90
+++ b/src/submodules/DynamicMesh/src/DynamicMesh_Class@IOMethods.F90
@@ -32,8 +32,8 @@ CHARACTER(*), PARAMETER :: myName = "obj_Import()"
 CHARACTER(:), ALLOCATABLE :: dsetname
 INTEGER(I4B) :: ii, xidim, elemType, jj, tsize1, tsize2
 LOGICAL(LGT) :: isok
-CLASS(ElemData_), POINTER :: elemdata_ptr
-CLASS(NodeData_), POINTER :: nodedata_ptr
+TYPE(ElemData_), POINTER :: elemdata_ptr
+TYPE(NodeData_), POINTER :: nodedata_ptr
 TYPE(NodeData_) :: nodedata
 INTEGER(I4B), ALLOCATABLE :: connectivity(:, :), elemNumber(:),  &
   & internalNptrs(:)
@@ -74,6 +74,7 @@ IF (isok) RETURN
 CALL obj%elementDataList%Initiate()
 CALL obj%nodeDataBinaryTree%Initiate()
 CALL obj%nodeDataList%Initiate()
+CALL obj%elementDataBinaryTree%Initiate()
 
 DO ii = 1, obj%tElements
 
@@ -81,12 +82,12 @@ DO ii = 1, obj%tElements
   CALL ElemDataSet(obj=elemdata_ptr, globalElemNum=elemNumber(ii),  &
     & localElemNum=ii, globalNodes=connectivity(:, ii))
   CALL obj%elementDataList%Add(elemdata_ptr)
+  CALL obj%elementDataBinaryTree%Insert(elemdata_ptr)
 
   DO jj = 1, SIZE(connectivity, 1)
 
     nodedata_ptr => NodeData_Pointer()
-    CALL NodeDataSet(obj=nodedata_ptr,  &
-      & globalNodeNum=connectivity(jj, ii),  &
+    CALL NodeDataSet(obj=nodedata_ptr, globalNodeNum=connectivity(jj, ii),  &
       & nodeType=TypeNode%boundary)
     ! TypeNode is defined in NodeData_Class
     ! The above step is unusual, but we know the position of
@@ -116,6 +117,9 @@ END DO
 
 CALL obj%nodeDataBinaryTree%SetID()
   !! This method will set the local node number in the binarytree
+
+CALL obj%elementDataBinaryTree%SetID()
+  !! This method will set the local element number in the binarytree
 
 obj%tNodes = obj%nodeDataBinaryTree%SIZE()
   !! This method returns the total number of nodes in mesh
@@ -164,18 +168,21 @@ CALL e%RaiseInformation(modName//'::'//myName//' - '// &
 END PROCEDURE obj_Import
 
 !----------------------------------------------------------------------------
-!                                                                 Display
+!                                                                  Display
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_Display
 CALL AbstractMeshDisplay(obj=obj, msg=msg, unitno=unitno)
 CALL obj%elementDataList%Display("elementDataList: ", unitno=unitno)
+CALL obj%elementDataBinaryTree%Display("elementDataBinaryTree: ",  &
+  & unitno=unitno)
+
 CALL obj%nodeDataBinaryTree%Display("nodeDataBinaryTree: ", unitno=unitno)
 CALL obj%nodeDataList%Display("nodeDataList: ", unitno=unitno)
 END PROCEDURE obj_Display
 
 !----------------------------------------------------------------------------
-!                                                            DisplayNodeData
+!                                                           DisplayNodeData
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_DisplayNodeData
@@ -185,7 +192,7 @@ CALL obj%nodeDataBinaryTree%Display("nodeDataBinaryTree: ", unitno=unitno)
 END PROCEDURE obj_DisplayNodeData
 
 !----------------------------------------------------------------------------
-!                                                         DisplayElementData
+!                                                        DisplayElementData
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_DisplayElementData

--- a/src/submodules/Mesh/src/Mesh_Class@NodeDataMethods.F90
+++ b/src/submodules/Mesh/src/Mesh_Class@NodeDataMethods.F90
@@ -28,7 +28,7 @@ MODULE PROCEDURE obj_InitiateNodeToElements
 ! Define internal  variables
 INTEGER(I4B) :: ii, jj, globalElemNum
 INTEGER(I4B), ALLOCATABLE :: local_nptrs(:)
-CHARACTER(LEN=*), PARAMETER :: myName = "obj_InitiateNodeToElements()"
+CHARACTER(*), PARAMETER :: myName = "obj_InitiateNodeToElements()"
 
 IF (obj%elemType .EQ. 0 .OR. obj%elemType .EQ. Point1) RETURN
 IF (obj%isNodeToElementsInitiated) THEN
@@ -58,7 +58,7 @@ MODULE PROCEDURE obj_InitiateNodetoNodes
 ! Define internal  variables
 INTEGER(I4B) :: iel, iLocalNode, iGlobalNode
 INTEGER(I4B), ALLOCATABLE :: globalNodes(:), NearElements(:)
-CHARACTER(LEN=*), PARAMETER :: myName = "obj_InitiateNodetoNodes()"
+CHARACTER(*), PARAMETER :: myName = "obj_InitiateNodetoNodes()"
 
 IF (obj%elemType .EQ. 0 .OR. obj%elemType .EQ. Point1) RETURN
 


### PR DESCRIPTION
- Adding BinaryTree for meshData
- Updates in initiate node to element method

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request includes changes to the DynamicMesh_Class.F90 and DynamicMesh_Class@NodeDataMethods.F90 files. The changes involve adding a USE statement for the ElemDataBinaryTree_Class module, updating the modName parameter, deallocating certain objects, modifying the IOMethods of the DynamicMesh class, and improving the display of node data. The code also includes changes to the declaration of variables and a loop that iterates through a list of node data.
> 
> ## What changed
> - Added a USE statement for the ElemDataBinaryTree_Class module
> - Updated the modName parameter
> - Deallocated certain objects
> - Modified the IOMethods of the DynamicMesh class
> - Improved the display of node data
> - Changed the declaration of variables
> - Modified a loop that iterates through a list of node data
> 
> ## How to test
> 1. Compile and run the program
> 2. Verify that the changes to the DynamicMesh_Class.F90 file have been applied correctly
> 3. Verify that the changes to the DynamicMesh_Class@NodeDataMethods.F90 file have been applied correctly
> 4. Test the display of node data to ensure it has been improved
> 
> ## Why make this change
> - The changes to the DynamicMesh_Class.F90 file add necessary dependencies and update parameters to improve the functionality of the DynamicMesh class.
> - The changes to the DynamicMesh_Class@NodeDataMethods.F90 file improve the display of node data and fix issues with variable declarations and loops. These changes enhance the overall performance and accuracy of the program.
</details>