### PR TITLE
NodeToNodes in DynamicMesh

### DIFF
--- a/src/modules/DynamicMesh/src/DynamicMesh_Class.F90
+++ b/src/modules/DynamicMesh/src/DynamicMesh_Class.F90
@@ -85,9 +85,9 @@ CONTAINS
   PROCEDURE, PUBLIC, PASS(obj) :: InitiateNodeToElements => &
     & obj_InitiateNodeToElements
 
-  !! Initiate node to node data
-  ! PROCEDURE, PUBLIC, PASS(obj) :: InitiateNodeToNodes => &
-  !   & obj_InitiateNodetoNodes
+  ! Initiate node to node data
+  PROCEDURE, PUBLIC, PASS(obj) :: InitiateNodeToNodes => &
+    & obj_InitiateNodetoNodes
   ! !! Initiate Node to nodes mapping
   ! PROCEDURE, PUBLIC, PASS(obj) :: InitiateExtraNodeToNodes => &
   !   & obj_InitiateExtraNodetoNodes
@@ -214,6 +214,20 @@ INTERFACE
   MODULE SUBROUTINE obj_InitiateNodeToElements(obj)
     CLASS(DynamicMesh_), INTENT(INOUT) :: obj
   END SUBROUTINE obj_InitiateNodeToElements
+END INTERFACE
+
+!----------------------------------------------------------------------------
+!                                       InitiateNodeToNodes@NodeDataMethods
+!----------------------------------------------------------------------------
+
+!> authors: Vikas Sharma, Ph. D.
+! date: 2024-01-30
+! summary: Generate node to nodes data
+
+INTERFACE
+  MODULE SUBROUTINE obj_InitiateNodeToNodes(obj)
+    CLASS(DynamicMesh_), INTENT(INOUT) :: obj
+  END SUBROUTINE obj_InitiateNodeToNodes
 END INTERFACE
 
 !----------------------------------------------------------------------------

--- a/src/submodules/DynamicMesh/src/DynamicMesh_Class@IOMethods.F90
+++ b/src/submodules/DynamicMesh/src/DynamicMesh_Class@IOMethods.F90
@@ -148,10 +148,12 @@ END DO
 
 ! TODO: Parallel
 DO ii = 1, SIZE(internalNptrs)
-  jj = internalNptrs(ii)
-  CALL NodeDataSet(obj=nodedata, globalNodeNum=jj)
+  ! jj = internalNptrs(ii)
+  ! CALL NodeDataSet(obj=nodedata, globalNodeNum=jj)
+  nodedata%globalNodeNum = internalNptrs(ii)
   nodedata_ptr => obj%nodeDataBinaryTree%GetValuePointer(VALUE=nodedata)
-  CALL NodeDataSet(obj=nodedata_ptr, nodeType=TypeNode%internal)
+  nodedata_ptr%nodeType = TypeNode%internal
+  ! CALL NodeDataSet(obj=nodedata_ptr, nodeType=TypeNode%internal)
 END DO
 
 nodedata_ptr => NULL()
@@ -187,8 +189,6 @@ END PROCEDURE obj_Display
 
 MODULE PROCEDURE obj_DisplayNodeData
 CALL obj%nodeDataList%Display("nodeDataList: ", unitno=unitno)
-CALL BlankLines(nol=2, unitno=unitno)
-CALL obj%nodeDataBinaryTree%Display("nodeDataBinaryTree: ", unitno=unitno)
 END PROCEDURE obj_DisplayNodeData
 
 !----------------------------------------------------------------------------
@@ -196,7 +196,7 @@ END PROCEDURE obj_DisplayNodeData
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_DisplayElementData
-CALL obj%elementDataList%Display("elementData: ", unitno=unitno)
+CALL obj%elementDataList%Display("elementDataList: ", unitno=unitno)
 END PROCEDURE obj_DisplayElementData
 
 END SUBMODULE IOMethods


### PR DESCRIPTION
- Adding node to nodes methods to DynamicMesh_Class

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request includes changes to the DynamicMesh_Class.F90 file. It comments out the InitiateNodeToNodes procedure and adds a new procedure with the same name. It also includes changes to the DynamicMesh_Class@IOMethods.F90 and DynamicMesh_Class@NodeDataMethods.F90 files. The changes involve modifying and commenting out certain lines of code related to node data. The code initializes variables, manipulates data structures, and performs calculations and operations on node data.
> 
> ## What changed
> - Commented out the InitiateNodeToNodes procedure and added a new procedure with the same name in the DynamicMesh_Class.F90 file.
> - Modified and commented out certain lines of code related to node data in the DynamicMesh_Class@IOMethods.F90 and DynamicMesh_Class@NodeDataMethods.F90 files.
> 
> 
> ## Why make this change
> - The changes were made to improve the functionality and efficiency of the DynamicMesh module.
> - The modifications to the InitiateNodeToNodes procedure and related code were made to address specific issues or requirements related to node data.
> - The changes aim to enhance the overall performance and reliability of the code.
</details>