### PR TITLE
Fixing bug in HDF5File_Method

### DIFF
--- a/src/modules/HDF5File/src/HDF5File_Method.F90
+++ b/src/modules/HDF5File/src/HDF5File_Method.F90
@@ -81,13 +81,15 @@ SUBROUTINE HDF5ReadIntMatrix(hdf5, VALUE, group, fieldname, myname,  &
 
   astr = group//"/"//fieldname
   isok0 = hdf5%pathExists(astr)
+  IF (isok0) THEN
+    CALL hdf5%READ(astr, VALUE)
+  END IF
+
   IF (check .AND. .NOT. isok0) THEN
     CALL e%RaiseError(modName//'::'//myName//" - "// &
       & '[INTERNAL ERROR]:: '//astr//' path does not exists.')
     RETURN
   END IF
-
-  CALL hdf5%READ(astr, VALUE)
 
   astr = ""
 END SUBROUTINE HDF5ReadIntMatrix
@@ -111,13 +113,16 @@ SUBROUTINE HDF5ReadRealMatrix(hdf5, VALUE, group, fieldname, myname,  &
 
   astr = group//"/"//fieldname
   isok0 = hdf5%pathExists(astr)
+
+  IF (isok0) THEN
+    CALL hdf5%READ(astr, VALUE)
+  END IF
+
   IF (check .AND. .NOT. isok0) THEN
     CALL e%RaiseError(modName//'::'//myName//" - "// &
       & '[INTERNAL ERROR]:: '//astr//' path does not exists.')
     RETURN
   END IF
-
-  CALL hdf5%READ(astr, VALUE)
 
   astr = ""
 END SUBROUTINE HDF5ReadRealMatrix
@@ -141,13 +146,16 @@ SUBROUTINE HDF5ReadRealVector(hdf5, VALUE, group, fieldname, myname,  &
 
   astr = group//"/"//fieldname
   isok0 = hdf5%pathExists(astr)
+
+  IF (isok0) THEN
+    CALL hdf5%READ(astr, VALUE)
+  END IF
+
   IF (check .AND. .NOT. isok0) THEN
     CALL e%RaiseError(modName//'::'//myName//" - "// &
       & '[INTERNAL ERROR]:: '//astr//' path does not exists.')
     RETURN
   END IF
-
-  CALL hdf5%READ(astr, VALUE)
 
   astr = ""
 END SUBROUTINE HDF5ReadRealVector
@@ -171,13 +179,16 @@ SUBROUTINE HDF5ReadIntVector(hdf5, VALUE, group, fieldname, myname,  &
 
   astr = group//"/"//fieldname
   isok0 = hdf5%pathExists(astr)
+
+  IF (isok0) THEN
+    CALL hdf5%READ(astr, VALUE)
+  END IF
+
   IF (check .AND. .NOT. isok0) THEN
     CALL e%RaiseError(modName//'::'//myName//" - "// &
       & '[INTERNAL ERROR]:: '//astr//' path does not exists.')
     RETURN
   END IF
-
-  CALL hdf5%READ(astr, VALUE)
 
   astr = ""
 
@@ -202,21 +213,24 @@ SUBROUTINE HDF5ReadScalar(hdf5, VALUE, group, fieldname, myname, modname,  &
 
   astr = group//"/"//fieldname
   isok0 = hdf5%pathExists(astr)
+
   IF (check .AND. .NOT. isok0) THEN
     CALL e%RaiseError(modName//'::'//myName//" - "// &
       & '[INTERNAL ERROR]:: '//astr//' path does not exists.')
     RETURN
   END IF
 
-  SELECT TYPE (VALUE)
+  IF (isok0) THEN
+    SELECT TYPE (VALUE)
 
-  TYPE is (INTEGER(I4B))
-    CALL hdf5%READ(astr, VALUE)
+    TYPE is (INTEGER(I4B))
+      CALL hdf5%READ(astr, VALUE)
 
-  TYPE is (REAL(DFP))
-    CALL hdf5%READ(astr, VALUE)
+    TYPE is (REAL(DFP))
+      CALL hdf5%READ(astr, VALUE)
 
-  END SELECT
+    END SELECT
+  END IF
 
   astr = ""
 


### PR DESCRIPTION
- Updating Read methods in HDF5File_Method

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the HDF5 file reading methods to check if a path exists before attempting to read from it. This prevents unnecessary errors and makes the code more robust.
> 
> ## What changed
> The `HDF5ReadIntMatrix`, `HDF5ReadRealMatrix`, `HDF5ReadRealVector`, `HDF5ReadIntVector`, and `HDF5ReadScalar` methods in `HDF5File_Method.F90` have been updated. Previously, these methods would attempt to read from a given path without checking if it exists. Now, they first check if the path exists before attempting to read from it.
> 
> ## How to test
> To test these changes, you can use any HDF5 file and attempt to read from a non-existent path. The methods should now handle this gracefully instead of throwing an error.
> 
> ## Why make this change
> This change makes the code more robust and prevents unnecessary errors. It is a good practice to check if a file or path exists before attempting to read from it. This change brings the code in line with this practice.
</details>